### PR TITLE
Task/wp 923 update exception form and listing

### DIFF
--- a/apcd_cms/src/apps/admin_exception/views.py
+++ b/apcd_cms/src/apps/admin_exception/views.py
@@ -26,7 +26,7 @@ class AdminExceptionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
     def get_exception_list_json(self, exception_content, *args, **kwargs):
         context = {}
 
-        context['header'] = ['Created', 'Entity Organization', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
+        context['header'] = ['Created', 'Payor Code', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
         context['status_options'] = ['All']
         context['org_options'] = ['All']
         context['outcome_modal_options'] = ['None', 'Granted', 'Denied', 'Withdrawn']
@@ -135,7 +135,7 @@ class AdminExceptionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
 
         context['query_str'] = queryStr
         page_info = paginator(page_num, exception_table_entries, limit)
-        context['page'] = [{'entity_name': obj['entity_name'], 'created_at': obj['created_at'], 'request_type': obj['request_type'], 
+        context['page'] = [{'payor_code': obj['payor_code'], 'created_at': obj['created_at'], 'request_type': obj['request_type'], 
                             'requestor_name': obj['requestor_name'], 'outcome': obj['outcome'], 'status': obj['status'], 
                             'approved_threshold': obj['approved_threshold'],'approved_expiration_date': obj['approved_expiration_date'], 
                             'notes': obj['notes'], 'exception_id': obj['exception_id'], 'view_modal_content': obj['view_modal_content'],
@@ -145,7 +145,7 @@ class AdminExceptionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
         context['page_num'] = page_num
         context['total_pages'] = page_info['page'].paginator.num_pages
 
-        context['pagination_url_namespaces'] = 'admin_submission:admin_submissions'
+        context['pagination_url_namespaces'] = 'admin_exception:list-exceptions'
 
         return context
 

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -738,7 +738,7 @@ def delete_registration_contact(reg_id, cont_id):
             conn.close()
 
 
-def create_other_exception(form, sub_data):
+def create_other_exception(form, exception, sub_data):
     cur = None
     conn = None
     values = ()
@@ -765,14 +765,14 @@ def create_other_exception(form, sub_data):
         ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         """
         values = (
-            form["otherExceptionBusinessName"],
+            _clean_value(int(exception['businessName'])),
             sub_data[1],
             sub_data[2],
             sub_data[3],
             _clean_value(form['requestorName']),
             _clean_email(form['requestorEmail']),
-            "Other",
-            _clean_date(form['expirationDateOther']),
+            _clean_value(form['exceptionType']),
+            _clean_date(exception['expiration_date']),
             _clean_value(form['justification']),
             "Pending"
         )
@@ -1395,13 +1395,28 @@ def update_exception(form):
             'status': 'status',
             'outcome': 'outcome',
         }
+        # Add mappings for the nested exception fields
+        # Form field name on left, db column on right
+        exception_columns = {
+            'fieldCode': 'field_number',
+            'expiration_date': 'requested_expiration_date',
+            'requested_threshold': 'requested_threshold',
+            'required_threshold': 'required_threshold',
+            'justification': 'explanation_justification',
+            'fileType': 'data_file'
+        }
         # To make sure fields are not blank. 
         # If they aren't, add column to update operation
         for field, column_name in columns.items():
             value = form.get(field)
             if value not in (None, ""):
                 set_values.append(f"{column_name} = %s")
-# to allow notes to be cleared, need to move notes out of the loop that ignores none
+        if form.get('exceptions') and len(form['exceptions']) > 0:
+            exception = form['exceptions'][0]  # Get the first exception
+            for field, column_name in exception_columns.items():
+                value = exception.get(field)
+                if value not in (None, ""):
+                    set_values.append(f"{column_name} = %s")
         operation += ", ".join(set_values) + ", notes = %s WHERE exception_id = %s"
         ## add last update time to all exceptions updates
         values = [
@@ -1416,6 +1431,14 @@ def update_exception(form):
                     values.append(int(value.replace('-', '')))
                 # server side clean values
                 else:
+                    values.append(_clean_value(value))
+
+        # Add values for exception fields
+        if form.get('exceptions') and len(form['exceptions']) > 0:
+            exception = form['exceptions'][0]
+            for field, column_name in exception_columns.items():
+                value = exception.get(field)
+                if value not in (None, ""):
                     values.append(_clean_value(value))
 
         # to allow notes to be cleared, need to move notes out of the loop that ignores none

--- a/apcd_cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
@@ -125,7 +125,7 @@ export const AdminExceptions: React.FC = () => {
             data?.page.map((row: ExceptionRow, rowIndex: number) => (
               <tr key={rowIndex}>
                 <td>{formatDate(row.created_at)}</td>
-                <td>{row.entity_name}</td>
+                <td>{row.payor_code}</td>
                 <td>{row.requestor_name}</td>
                 <td>{row.request_type}</td>
                 <td>{row.outcome}</td>

--- a/apcd_cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewExceptionModal/ViewExceptionModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Modal, ModalHeader, ModalBody, Row, Col } from 'reactstrap';
+import { cdl, useCDLs } from 'hooks/cdls';
 import { ExceptionRow } from 'hooks/admin';
 import { formatUTCDate } from 'utils/dateUtil';
-import styles from './ViewExceptionModal.module.css';
 
 export const ViewExceptionModal: React.FC<{
   exception: ExceptionRow;
@@ -35,6 +35,39 @@ export const ViewExceptionModal: React.FC<{
     updated_at,
   } = exception.view_modal_content;
 
+  // Use data_file_name from form to find cdl field_list_code and cdl field_list_value
+  const mapFileTypeToCDL = (data_file_name: string): string => {
+    const map: { [key: string]: string } = {
+      'dental claims': 'dc',
+      'medical claims': 'mc',
+      'member eligibility': 'me',
+      'pharmacy claims': 'pc',
+      'provider': 'pv',
+    };
+    const fileType = data_file_name.toLowerCase();
+    for (const [key, value] of Object.entries(map)) {
+      if (fileType.includes(key)) {
+        return value;
+      }
+    }
+    return fileType.substring(0, 2);
+  };
+
+const cdl = (data_file_name: string): cdl => {
+  const fileTypeCode = mapFileTypeToCDL(data_file_name);
+  const {
+    data: fetchedCDLData,
+    isLoading: cdlLoading,
+    isError: cdlError,
+  } = useCDLs(fileTypeCode);
+  
+  const cdls = fetchedCDLData?.cdls.find(
+    (cdl) => cdl.field_list_code === field_number
+  );
+  
+  return cdls as cdl;
+}
+
   return (
     <Modal title="View Exception" isOpen={isOpen} toggle={onClose} size="lg">
       <ModalHeader close={closeBtn}>Exception Detail</ModalHeader>
@@ -45,7 +78,8 @@ export const ViewExceptionModal: React.FC<{
             <Row>
               <Col md={{ size: 4, offset: 1 }}>Created</Col>
               <Col md={7}>
-                {(created_at && new Date(created_at).toLocaleString()) || 'None'}
+                {(created_at && new Date(created_at).toLocaleString()) ||
+                  'None'}
               </Col>
             </Row>
             <Row>
@@ -78,7 +112,16 @@ export const ViewExceptionModal: React.FC<{
             </Row>
             <Row>
               <Col md={{ size: 4, offset: 1 }}>Field Number</Col>
-              <Col md={7}>{field_number || 'None'}</Col>
+              {field_number && data_file_name ? (
+                <Col md={7}>
+                  {(() => {
+                    const cdlValue = cdl(data_file_name);
+                    return cdlValue?.field_list_code + ' - ' + cdlValue?.field_list_value;
+                  })()}
+                </Col>
+              ) : (
+                <Col md={7}>{'Unavailable'}</Col>
+              )}
             </Row>
             <Row>
               <Col md={{ size: 4, offset: 1 }}>Required Threshold</Col>
@@ -119,7 +162,8 @@ export const ViewExceptionModal: React.FC<{
             <Row>
               <Col md={{ size: 4, offset: 1 }}>Last Updated</Col>
               <Col md={7}>
-                {(updated_at && new Date(updated_at).toLocaleString()) || 'None'}
+                {(updated_at && new Date(updated_at).toLocaleString()) ||
+                  'None'}
               </Col>
             </Row>
             <hr />

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { useFormikContext, Field, ErrorMessage } from 'formik';
+import { useFormikContext, Field } from 'formik';
 import { cdlObject, useCDLs, cdl } from 'hooks/cdls';
 import { Entities, useEntities } from 'hooks/entities';
 import styles from './ExceptionForm.module.css';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import SectionMessage from 'core-components/SectionMessage';
-import { Link } from 'react-router-dom';
 import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
 
-export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
+export const ExceptionForm: React.FC<{
+  index: number;
+  isModal?: boolean;
+  exceptionType: string;
+}> = ({ index = 0, isModal = false, exceptionType }) => {
   const [cdlData, setCdlData] = useState<cdlObject>();
   const [selectedCDL, setSelectedCDL] = useState<cdl>();
 
@@ -61,14 +64,22 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
 
   return (
     <>
-      <hr />
-      <h4>Requested Threshold Reduction {index + 1}</h4>
-      <FieldWrapper
-        name={`exceptions.${index}.businessName`}
-        label="Business Name"
-        required={true}
-      >
-        {submitterData && (
+      {!isModal && (
+        <>
+          <hr />
+          {exceptionType === 'threshold' && (
+            <h4>Requested Threshold Reduction {index + 1}</h4>
+          )}
+          {exceptionType === 'other' && <h4>Exception Details</h4>}
+        </>
+      )}
+      {!isModal && submitterData && (
+        // UTH APCD admin requested business name is not editable in modal
+        <FieldWrapper
+          name={`exceptions.${index}.businessName`}
+          label="Business Name"
+          required={!isModal}
+        >
           <>
             <Field
               as="select"
@@ -86,126 +97,149 @@ export const ExceptionForm: React.FC<{ index: number }> = ({ index }) => {
               ))}
             </Field>
           </>
-        )}
-        {entitiesError && (
-          <SectionMessage type="error">
-            There was an error finding your associated businesses.{' '}
-            <a href="/workbench/dashboard/tickets/create" className="wb-link">
-              Please submit a ticket.
-            </a>
-          </SectionMessage>
-        )}
-      </FieldWrapper>
-      <FieldWrapper
-        name={`exceptions[${index}].fileType`}
-        label="File Type"
-        required={true}
-      >
-        <Field
-          as="select"
-          name={`exceptions[${index}].fileType`}
-          id={`exceptions[${index}].fileType`}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setFieldValue(`exceptions[${index}].fileType`, e.target.value);
-            setFieldValue(`exceptions[${index}].fieldCode`, '');
-          }}
-        >
-          <option value="">Select a File Type</option>
-          <option value="dc">Dental Claims</option>
-          <option value="mc">Medical Claims</option>
-          <option value="me">Member Eligibility</option>
-          <option value="pc">Pharmacy Claims</option>
-          <option value="pv">Provider</option>
-        </Field>
-      </FieldWrapper>
-      <FieldWrapper
-        name={`exceptions[${index}].fieldCode`}
-        label="Field Code"
-        required={true}
-      >
-        <Field
-          as="select"
-          name={`exceptions[${index}].fieldCode`}
-          id={`exceptions[${index}].fieldCode`}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setSelectedCDL(
-              cdlData?.cdls.find(
-                (cdl) => cdl.field_list_code === e.target.value
-              )
-            );
-            setFieldValue(`exceptions[${index}].fieldCode`, e.target.value);
-          }}
-        >
-          {cdlData ? (
-            <>
-              <option value="">Select Field Code</option>
-              {cdlData.cdls.map((cdl: any) => (
-                <option
-                  key={cdl.field_list_code}
-                  id={cdl.field_list_code}
-                  value={cdl.field_list_code}
-                >
-                  {cdl.field_list_code}
-                  {' - '}
-                  {cdl.field_list_value}
-                </option>
-              ))}
-            </>
-          ) : (
-            <option value="">Select a File Type Above First</option>
+          {entitiesError && (
+            <SectionMessage type="error">
+              There was an error finding your associated businesses.{' '}
+              <a href="/workbench/dashboard/tickets/create" className="wb-link">
+                Please submit a ticket.
+              </a>
+            </SectionMessage>
           )}
-        </Field>
-      </FieldWrapper>
-      <div className={styles.fieldRows}>
-        <FieldWrapper
-          name={`exceptions[${index}].expiration_date`}
-          label="Expiration Date"
-          required={true}
-        >
-          <Field
-            type="date"
+        </FieldWrapper>
+      )}
+      {exceptionType.toLowerCase() === 'threshold' && (
+        <>
+          <FieldWrapper
+            name={`exceptions[${index}].fileType`}
+            label="File Type"
+            required={!isModal}
+          >
+            <Field
+              as="select"
+              name={`exceptions[${index}].fileType`}
+              id={`exceptions[${index}].fileType`}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setFieldValue(`exceptions[${index}].fileType`, e.target.value);
+                setFieldValue(`exceptions[${index}].fieldCode`, '');
+              }}
+            >
+              <option value="">Select a File Type</option>
+              <option value="dc">Dental Claims</option>
+              <option value="mc">Medical Claims</option>
+              <option value="me">Member Eligibility</option>
+              <option value="pc">Pharmacy Claims</option>
+              <option value="pv">Provider</option>
+            </Field>
+          </FieldWrapper>
+          <FieldWrapper
+            name={`exceptions[${index}].fieldCode`}
+            label="Field Code"
+            required={!isModal}
+          >
+            <Field
+              as="select"
+              name={`exceptions[${index}].fieldCode`}
+              id={`exceptions[${index}].fieldCode`}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setSelectedCDL(
+                  cdlData?.cdls.find(
+                    (cdl) => cdl.field_list_code === e.target.value
+                  )
+                );
+                setFieldValue(`exceptions[${index}].fieldCode`, e.target.value);
+              }}
+            >
+              {cdlData ? (
+                <>
+                  <option value="">Select Field Code</option>
+                  {cdlData.cdls.map((cdl: any) => (
+                    <option
+                      key={cdl.field_list_code}
+                      id={cdl.field_list_code}
+                      value={cdl.field_list_code}
+                    >
+                      {cdl.field_list_code}
+                      {' - '}
+                      {cdl.field_list_value}
+                    </option>
+                  ))}
+                </>
+              ) : (
+                <option value="">Select a File Type Above First</option>
+              )}
+            </Field>
+          </FieldWrapper>
+          <div className={styles.fieldRows}>
+            <FieldWrapper
+              name={`exceptions[${index}].expiration_date`}
+              label="Requested Expiration Date"
+              required={!isModal}
+            >
+              <Field
+                type="date"
+                name={`exceptions[${index}].expiration_date`}
+                id={`exceptions[${index}].expiration_date`}
+              ></Field>
+            </FieldWrapper>
+            <FieldWrapper
+              name={`exceptions[${index}].requested_threshold`}
+              label="Requested Threshold Percentage"
+              required={!isModal}
+              description={
+                selectedCDL &&
+                (selectedCDL.threshold_value != 0 ? (
+                  <>
+                    Must be less than the {selectedCDL.threshold_value}{' '}
+                    required.
+                  </>
+                ) : (
+                  <>
+                    This field code does not require an exception submission.
+                    <br /> Please choose another.
+                  </>
+                ))
+              }
+            >
+              <Field
+                type="number"
+                name={`exceptions[${index}].requested_threshold`}
+                id={`exceptions[${index}].requested_threshold`}
+                className={styles.thresholdRequested}
+                max={selectedCDL?.threshold_value}
+              ></Field>
+            </FieldWrapper>
+            <FieldWrapper
+              name={`exceptions[${index}].required_threshold`}
+              label="Required Threshold Percentage"
+              required={false}
+            >
+              <Field
+                className={styles.requiredThreshold}
+                type="number"
+                readOnly
+                name={`exceptions[${index}].required_threshold`}
+                id={`exceptions[${index}].required_threshold`}
+              ></Field>
+            </FieldWrapper>
+          </div>
+        </>
+      )}
+      {exceptionType.toLowerCase() === 'other' && (
+        <div className={styles.fieldRows}>
+          <FieldWrapper
             name={`exceptions[${index}].expiration_date`}
-            id={`exceptions[${index}].expiration_date`}
-          ></Field>
-        </FieldWrapper>
-        <FieldWrapper
-          name={`exceptions[${index}].requested_threshold`}
-          label="Requested Threshold Percentage"
-          required={true}
-          description={
-            selectedCDL &&
-            (selectedCDL.threshold_value != 0 ? (
-              <>Must be less than the {selectedCDL.threshold_value} required.</>
-            ) : (
-              <>
-                This field code does not require an exception submission.
-                <br /> Please choose another.
-              </>
-            ))
-          }
-        >
-          <Field
-            type="number"
-            name={`exceptions[${index}].requested_threshold`}
-            id={`exceptions[${index}].requested_threshold`}
-            className={styles.thresholdRequested}
-            max={selectedCDL?.threshold_value}
-          ></Field>
-        </FieldWrapper>
-        <FieldWrapper
-          name={`exceptions[${index}].required_threshold`}
-          label="Required Threshold Percentage"
-          required={true}
-        >
-          <Field
-            className={styles.requiredThreshold}
-            type="number"
-            readOnly
-            name={`exceptions[${index}].required_threshold`}
-            id={`exceptions[${index}].required_threshold`}
-          ></Field>
-        </FieldWrapper>
-      </div>
+            label="Requested Expiration Date"
+            required={!isModal}
+          >
+            <Field
+              type="date"
+              name={`exceptions[${index}].expiration_date`}
+              id={`exceptions[${index}].expiration_date`}
+              className={styles.expirationDate}
+            ></Field>
+          </FieldWrapper>
+        </div>
+      )}
     </>
   );
 };

--- a/apcd_cms/src/client/src/hooks/admin/index.ts
+++ b/apcd_cms/src/client/src/hooks/admin/index.ts
@@ -67,6 +67,8 @@ export type ExtensionResult = {
 export type ExceptionModalContent = {
   created_at: string;
   entity_name: string;
+  submitter_id: string;
+  payor_code: string;
   requestor_name: string;
   requestor_email: string;
   request_type: string;
@@ -88,6 +90,8 @@ export type ExceptionModalContent = {
 export type ExceptionRow = {
   created_at: string;
   entity_name: string;
+  submitter_id: number;
+  payor_code: string;
   requestor_name: string;
   request_type: string;
   requested_threshold: string;


### PR DESCRIPTION
## Overview

#### Copied from Core-CMS-Custom branch [task/wp-923-Update-Exception-form-and-listing](https://github.com/TACC/Core-CMS-Custom/pull/477) 
Adds exception form to admin exception modal

## Related


- Addresses all TODOs in [WP-923](https://tacc-main.atlassian.net/browse/WP-923) except updating CDL to new version

## Changes

- Prettier changes for exception only
- Adds submitter info in ExceptionModalContent and ExceptionRow type
- Factors out threshold/other logic to form only on exception form page
- Adds ExceptionForm component to admin exception edit modal pulling in values using useFormFields formik hook
- Values of form on Submissions -> Request Exception now are save when switching between other and threshold exception types. Removes warning 
- Shows payor_code in admin table rather than the entity organization (per email)
- Updates queries to handle form data
- Shows CDL description next to field_code_number in Exception View modal

## Testing

1. Go to [http://localhost:8000/administration/list-exceptions/](http://localhost:8000/administration/list-exceptions/) and click Action -> Edit
2. Try and edit and submit all fields and make sure it updates
3. Go to [http://localhost:8000/submissions/exception/](http://localhost:8000/submissions/exception/) and try and submit a form with multiple exceptions and check that it submits
4. Go back to admin listing, and make sure your new exception submission displays correctly.
5. Go to admin view exception modal and make sure CDL has a description next to code
6. Make sure admin table shows payor code instead of the entity org name

## UI
<img width="868" alt="Screenshot 2025-05-06 at 2 41 33 PM" src="https://github.com/user-attachments/assets/b44f57f4-aa13-40e7-965d-c4976c77fe52" />
<img width="840" alt="Screenshot 2025-05-06 at 2 42 54 PM" src="https://github.com/user-attachments/assets/3ec4f7bd-1239-4ab7-aaf2-9bd8ce04df81" />


<!--
## Notes

…
-->
