### PR TITLE
Update build.yml to include release tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           context: apcd_cms
           push: true
-          tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }}
+          tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }},taccwma/apcd-cms:${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Added syntax to generate the release tag on the APCD image.

## Overview

- Grabbed the syntax from here: https://dev.to/natilou/automating-tag-creation-release-and-docker-image-publishing-with-github-actions-49jg

## Related

- N/A

## Changes

- Adds release tag to published docker image.

## Testing

1. Run build/publish workflow, check that dockerhub image has release tag added.

## UI

- N/A

## Notes

- None.
