### PR TITLE
updated the cdl query to use new table

### DIFF
--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -852,6 +852,42 @@ def create_threshold_exception(form, exception, sub_data):
             conn.close()
 
 
+# def get_cdl_exceptions(file_type):
+#     cur = None
+#     conn = None
+#     try:
+#         conn = psycopg.connect(
+#             host=APCD_DB['host'],
+#             dbname=APCD_DB['database'],
+#             user=APCD_DB['user'],
+#             password=APCD_DB['password'],
+#             port=APCD_DB['port'],
+#             sslmode='require'
+#         )
+#         query = """ SELECT c1.item_code as field_list_code,
+#         c1.item_value AS field_list_value,
+#         c2.item_value AS threshold_value
+#         FROM standard_codes c1
+#         LEFT JOIN standard_codes c2
+#             ON c2.item_code = c1.item_code
+#         WHERE c1.list_name=%s AND c2.list_name=%s """
+#
+#         cur = conn.cursor()
+#         file_type = _clean_value(file_type)
+#         field_list = 'field_list_' + file_type
+#         threshold_list = 'threshold_list_' + file_type
+#         cur.execute(query, (field_list, threshold_list))
+#         return cur.fetchall()
+#
+#     except Exception as error:
+#         logger.error(error, exc_info=True)
+#
+#     finally:
+#         if cur is not None:
+#             cur.close()
+#         if conn is not None:
+#             conn.close()
+
 def get_cdl_exceptions(file_type):
     cur = None
     conn = None
@@ -864,19 +900,19 @@ def get_cdl_exceptions(file_type):
             port=APCD_DB['port'],
             sslmode='require'
         )
-        query = """ SELECT c1.item_code as field_list_code, 
-        c1.item_value AS field_list_value, 
-        c2.item_value AS threshold_value 
-        FROM standard_codes c1 
-        LEFT JOIN standard_codes c2 
-            ON c2.item_code = c1.item_code 
-        WHERE c1.list_name=%s AND c2.list_name=%s """
+        query = """ SELECT  cdl_number as field_list_code, 
+        data_element_name as field_list_value,
+        threshold as threshold_value,  
+        required,
+        description 
+        FROM cdl_ref 
+        WHERE lower(file_type)=%s 
+        and lower(required) in('required','conditional') 
+        and threshold between 0 and 100 and cdl_version='3.0.1' ORDER BY cdl_order """
 
         cur = conn.cursor()
         file_type = _clean_value(file_type)
-        field_list = 'field_list_' + file_type
-        threshold_list = 'threshold_list_' + file_type
-        cur.execute(query, (field_list, threshold_list))
+        cur.execute(query, (file_type,))
         return cur.fetchall()
 
     except Exception as error:


### PR DESCRIPTION
## Overview

UTHealth has implemented a new CDL table and has requested we start referring to that rather than the old, unmaintained table.
Updated the CDL query to the new provided query. 

## Related

- [WP-974](https://tacc-main.atlassian.net/browse/WP-974)


## Changes

get_cdl_exceptions table updated to refer to new table (query provided by UTHealth).

## Testing

1. Navigate to http://localhost:8000/submissions/exception/ and verify that selecting the threshold field codes properly auto-fills threshold field
2. Verify form submits properly

## Notes

Lingering questions: should we make the version a setting or is it fine as just a
(single) hardcoded value? Are there any other pages/forms that reference this cdl query? 


