### PR TITLE
bug/WP-973: handle no records for default filter

### DIFF
--- a/apcd_cms/src/apps/admin_exception/views.py
+++ b/apcd_cms/src/apps/admin_exception/views.py
@@ -65,7 +65,6 @@ class AdminExceptionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
                 'approved_threshold': exception[17],
                 'approved_expiration_date': exception[18],
                 'status': title_case(exception[19]) if exception[19] else 'None',
-                'status': title_case(exception[19]) if exception[19] else 'None',
                 'notes': exception[20],
                 'entity_name': exception[21],
                 'data_file_name': exception[22],

--- a/apcd_cms/src/apps/admin_exception/views.py
+++ b/apcd_cms/src/apps/admin_exception/views.py
@@ -27,7 +27,7 @@ class AdminExceptionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
         context = {}
 
         context['header'] = ['Created', 'Entity Organization - Payor Code', 'Requestor Name', 'Exception Type', 'Outcome', 'Status', 'Actions']
-        context['status_options'] = ['All']
+        context['status_options'] = ['All', 'Pending']
         context['org_options'] = ['All']
         context['outcome_modal_options'] = ['None', 'Granted', 'Denied', 'Withdrawn']
         context['status_modal_options'] = ['None', 'Complete', 'Pending']

--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -29,7 +29,7 @@ class AdminExtensionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
         context = {}
 
         context['header'] = ['Created', 'Entity Organization', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
-        context['status_options'] = ['All']
+        context['status_options'] = ['All', 'Pending']  # 'Pending' is default filter value on page load, need to have it hard-coded to not miss option once we reach client-side
         context['org_options'] = ['All']
         context['outcome_options'] = []
         context['extensions'] = []


### PR DESCRIPTION
## Overview

…

## Related

- [WP-973](https://tacc-main.atlassian.net/browse/WP-973)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Hard-codes the default 'Pending' option for the status filter for both admin extensions + exceptions
…

## Testing

1. *may be a better way to test this from the db, but can manipulate data in the views with the following to force the "no Pending" situation*:
  - In `apps/admin_extension/views.py`, line 110, change line to: `'ext_status': "Complete" if title_case(ext[7]) == "Pending" else title_case(ext[7]) if ext[7] else "None",`
  - In `apps/admin_exception/views.py`, line 67, change line to: `'status': "Complete" if title_case(exception[19]) == "Pending" else title_case(exception[19]) if exception[19] else 'None',`
2. Go to both listing pages locally and confirm the page loads, the table shows 'No Data Available', and the status filter shows 'Pending'
3. Also confirm all other status filter options work as expected, and clear button reloads listing back to initial 'Pending' state in step (2)

## UI

…

<!--
## Notes

…
-->
