### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,7 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         tags: |
-          type=sha
-          type=semver,pattern={{version}}
           type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,17 @@ jobs:
           echo "BRANCH_NAME=$(echo ${GITHUB_REF_NAME} | sed 's/[^[:alnum:]\.\_\-]/-/g')" >> "$GITHUB_OUTPUT";
           echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT";
 
+      - name: Extract release version
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        tags: |
+          type=sha
+          type=semver,pattern={{version}}
+          type=semver,pattern=v{{version}}
+          type=semver,pattern=v{{major}}.{{minor}}
+          type=semver,pattern=v{{major}}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
+        images: taccwma/apcd-cms
         tags: |
           type=semver,pattern=v{{version}}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           context: apcd_cms
           push: true
-          tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }},taccwma/apcd-cms:${{ steps.meta.outputs.tags }}
+          tags: taccwma/apcd-cms:${{ steps.vars.outputs.SHORT_SHA }},taccwma/apcd-cms:${{ steps.vars.outputs.BRANCH_NAME }},taccwma/apcd-cms:${{ steps.meta.outputs.tags || 'latest' }}


### PR DESCRIPTION
Added the `latest` tag as the default for the build workflow if no tag is applied when pushing a new APCD image.

## Overview

Quick patch.

## Related

- None.

## Changes

- Added default `latest` tag.

## Testing

1. Push to `main` and succesfully build/tag/push a docker image.

## UI

- N/A

## Notes

- None.
