### PR TITLE
task/wp-924-Update-Extensions-Form-Admin-list

### DIFF
--- a/apcd_cms/src/apps/admin_extension/static/admin_extension/css/table.css
+++ b/apcd_cms/src/apps/admin_extension/static/admin_extension/css/table.css
@@ -3,7 +3,7 @@
     /* To label the cells */
     /* RFE: Add `data-label` to each cell so we can use `attr(data-label)` */
     .extension-table td:nth-of-type(1):before { content: "Created"; }
-    .extension-table td:nth-of-type(2):before { content: "Entity Organization"; }
+    .extension-table td:nth-of-type(2):before { content: "Entity Organization - Payor Code"; }
     .extension-table td:nth-of-type(3):before { content: "Requestor Name"; }
     .extension-table td:nth-of-type(4):before { content: "Extension Type"; }
     .extension-table td:nth-of-type(5):before { content: "Outcome"; }

--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -141,21 +141,9 @@ class UpdateExtensionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
 
     def put(self, request, ext_id):
         data = json.loads(request.body)
-
-        updated_data = {}
-        updated_data['extension_id'] = ext_id
-        updated_data['status'] = data['ext_status']
-        updated_data['outcome'] = data['ext_outcome']
-        updated_data['approved_expiration_date'] = data['approved_expiration_date']
-        updated_data['applicable_data_period'] = data['applicable_data_period']
-        updated_data['notes'] = data['notes']
-
-        errors = []
-        extension_response = update_extension(updated_data)
+        extension_response = update_extension(data)
         if self._err_msg(extension_response):
-            errors.append(self._err_msg(extension_response))
-        if len(errors) != 0:
-            logger.error(errors)
-            return JsonResponse({'message': 'Cannot edit extension'}, status=500)
+            logger.error(self._err_msg(extension_response))
+            return JsonResponse({'response': 'error', 'message': 'Cannot edit extension'}, status=500)
 
         return JsonResponse({'response': 'success'})

--- a/apcd_cms/src/apps/admin_extension/views.py
+++ b/apcd_cms/src/apps/admin_extension/views.py
@@ -28,7 +28,7 @@ class AdminExtensionsApi(APCDAdminAccessAPIMixin, BaseAPIView):
     def get_extensions_list_json(self, extensions, *args, **kwargs):
         context = {}
 
-        context['header'] = ['Created', 'Entity Organization', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
+        context['header'] = ['Created', 'Entity Organization - Payor Code', 'Requestor Name', 'Extension Type', 'Outcome', 'Status', 'Approved Expiration', 'Actions']
         context['status_options'] = ['All', 'Pending']  # 'Pending' is default filter value on page load, need to have it hard-coded to not miss option once we reach client-side
         context['org_options'] = ['All']
         context['outcome_options'] = []

--- a/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
@@ -129,7 +129,9 @@ export const AdminExtensions: React.FC = () => {
             data?.page.map((row: ExtensionRow, rowIndex: number) => (
               <tr key={rowIndex}>
                 <td>{formatDate(row.created)}</td>
-                <td>{row.org_name}</td>
+                <td>
+                  {row.org_name} - {row.payor_code}
+                </td>
                 <td>{row.requestor}</td>
                 <td>{row.type}</td>
                 <td>{row.ext_outcome}</td>

--- a/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -22,14 +22,11 @@ interface EditExtensionModalProps {
 
 interface FormValues {
   extensions: {
-    businessName: string;
     extensionType: string;
     applicableDataPeriod: string;
     requestedTargetDate: string;
     currentExpectedDate: string;
   }[];
-  requestorName: string;
-  requestorEmail: string;
   justification: string;
   ext_outcome: string;
   ext_status: string;
@@ -76,15 +73,12 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
     const initialValues: FormValues = {
       extensions: [
         {
-          businessName: currentExtension.org_name,
           extensionType: currentExtension.type.toLowerCase().replace(" ", '_'),
           applicableDataPeriod: currentExtension.applicable_data_period,
           requestedTargetDate: currentExtension.requested_target_date,
           currentExpectedDate: currentExtension?.current_expected_date,
         },
       ],
-      requestorName: currentExtension.requestor,
-      requestorEmail: currentExtension.requestor_email,
       justification: currentExtension.explanation_justification,
       ext_outcome: currentExtension.ext_outcome,
       ext_status: currentExtension.ext_status,

--- a/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -77,7 +77,7 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
       extensions: [
         {
           businessName: currentExtension.org_name,
-          extensionType: currentExtension.type.toLowerCase(),
+          extensionType: currentExtension.type.toLowerCase().replace(" ", '_'),
           applicableDataPeriod: currentExtension.applicable_data_period,
           requestedTargetDate: currentExtension.requested_target_date,
           currentExpectedDate: currentExtension?.current_expected_date,

--- a/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/EditExtensionModal/EditExtensionModal.tsx
@@ -2,17 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { Modal, ModalBody, ModalHeader, Row, Col, Alert } from 'reactstrap';
 import { Field, useFormik, FormikHelpers, FormikProvider } from 'formik';
 import { fetchUtil } from 'utils/fetchUtil';
-import { formatDate, formatUTCDate } from 'utils/dateUtil';
 import * as Yup from 'yup';
 import { ExtensionRow } from 'hooks/admin';
-import { useSubmitterDataPeriods } from 'hooks/entities';
+import { useSubmitterDataPeriods, useEntities } from 'hooks/entities';
 import QueryWrapper from 'core-wrappers/QueryWrapper';
-import {
-  convertPeriodLabelToApiValue,
-  convertApiValueToPeriodLabel,
-} from 'utils/dateUtil';
+import { convertPeriodLabelToApiValue } from 'utils/dateUtil';
 import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
 import Button from 'core-components/Button';
+import ExtensionFormInfo from 'apcd-components/Submitter/Extensions/ExtensionFormInfo';
 
 interface EditExtensionModalProps {
   isVisible: boolean;
@@ -24,11 +21,20 @@ interface EditExtensionModalProps {
 }
 
 interface FormValues {
+  extensions: {
+    businessName: string;
+    extensionType: string;
+    applicableDataPeriod: string;
+    requestedTargetDate: string;
+    currentExpectedDate: string;
+  }[];
+  requestorName: string;
+  requestorEmail: string;
+  justification: string;
   ext_outcome: string;
   ext_status: string;
   ext_id: string;
   approved_expiration_date: string;
-  applicable_data_period: string;
   notes: string;
 }
 
@@ -53,97 +59,44 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
     error: submitterDataError,
   } = useSubmitterDataPeriods(extension?.submitter_id);
 
+  const {
+    data: entitiesData,
+    isLoading: entitiesLoading,
+    isError: entitiesError,
+  } = useEntities();
+
   useEffect(() => {
     setCurrentExtension(extension);
   }, [extension]);
 
   if (!currentExtension) return null;
 
-  const extensionFields = [
-    {
-      label: 'Created',
-      value: currentExtension?.created
-        ? formatDate(currentExtension.created)
-        : 'None',
-    },
-    {
-      label: 'Entity Organization',
-      value: currentExtension?.org_name,
-    },
-    {
-      label: 'Requestor',
-      value: currentExtension?.requestor,
-    },
-    {
-      label: 'Requestor Email',
-      value: currentExtension?.requestor_email,
-    },
-    {
-      label: 'Extension Type',
-      value: currentExtension?.type,
-    },
-    {
-      label: 'Status',
-      value: currentExtension?.ext_status,
-    },
-    {
-      label: 'Outcome',
-      value: currentExtension?.ext_outcome,
-    },
-    {
-      label: 'Applicable Data Period',
-      value: currentExtension?.applicable_data_period,
-    },
-    {
-      label: 'Current Expected Date',
-      value:
-        currentExtension?.current_expected_date &&
-        currentExtension?.current_expected_date !== 'None'
-          ? formatUTCDate(currentExtension?.current_expected_date)
-          : 'None',
-    },
-    {
-      label: 'Requested Target Date',
-      value:
-        currentExtension?.requested_target_date &&
-        currentExtension?.requested_target_date !== 'None'
-          ? formatUTCDate(currentExtension?.requested_target_date)
-          : 'None',
-    },
-    {
-      label: 'Approved Expiration Date',
-      value:
-        currentExtension?.approved_expiration_date &&
-        currentExtension?.approved_expiration_date !== 'None'
-          ? formatUTCDate(currentExtension?.approved_expiration_date)
-          : 'None',
-    },
-    {
-      label: 'Extension Justification',
-      value: currentExtension?.explanation_justification,
-    },
-    {
-      label: 'Extension Notes',
-      value: currentExtension?.notes,
-    },
-    {
-      label: 'Last Updated',
-      value:
-        currentExtension?.updated_at && currentExtension?.updated_at !== 'None'
-          ? formatDate(currentExtension?.updated_at)
-          : 'None',
-    },
-  ];
-
   // Use the custom hook to get form fields and validation
   const useFormFields = () => {
     const initialValues: FormValues = {
-      ...currentExtension,
-      ext_id: currentExtension?.ext_id,
+      extensions: [
+        {
+          businessName: currentExtension.org_name,
+          extensionType: currentExtension.type.toLowerCase(),
+          applicableDataPeriod: currentExtension.applicable_data_period,
+          requestedTargetDate: currentExtension.requested_target_date,
+          currentExpectedDate: currentExtension?.current_expected_date,
+        },
+      ],
+      requestorName: currentExtension.requestor,
+      requestorEmail: currentExtension.requestor_email,
+      justification: currentExtension.explanation_justification,
+      ext_outcome: currentExtension.ext_outcome,
+      ext_status: currentExtension.ext_status,
+      ext_id: currentExtension.ext_id,
+      approved_expiration_date: currentExtension.approved_expiration_date,
       notes: currentExtension?.notes || 'None', // Set notes to 'None' if it is null
     };
 
     const validationSchema = Yup.object({
+      justificiation: Yup.string()
+        .max(2000, 'Notes cannot exceed 2000 characters')
+        .nullable(),
       notes: Yup.string()
         .max(2000, 'Notes cannot exceed 2000 characters')
         .nullable(),
@@ -161,7 +114,7 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
     const api_values = {
       ...values,
       applicable_data_period: convertPeriodLabelToApiValue(
-        values['applicable_data_period']
+        values.extensions[0].applicableDataPeriod
       ),
     };
     const url = `administration/update-extension/${ext_id}/`;
@@ -180,7 +133,7 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
           ...prevExtension!,
           ext_status: values.ext_status,
           ext_outcome: values.ext_outcome,
-          applicable_data_period: values.applicable_data_period,
+          applicable_data_period: values.extensions[0].applicableDataPeriod,
           approved_expiration_date: values.approved_expiration_date,
           notes: values.notes,
           updated_at: new Date().toISOString(),
@@ -239,28 +192,46 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
           {currentExtension.org_name}
         </ModalHeader>
         <ModalBody>
-          <h4 className="modal-header">Edit Selected Extension</h4>
           <QueryWrapper
             isLoading={submitterDataLoading}
             error={submitterDataError as Error}
           >
             <FormikProvider value={formik}>
               <form onSubmit={formik.handleSubmit}>
+                {formik.values.extensions.map((extension, index) => (
+                  <ExtensionFormInfo
+                    key={index}
+                    index={index}
+                    submitterData={entitiesData}
+                    isModal={true}
+                  />
+                ))}
                 <Row>
                   <Col md={3}>
                     <FieldWrapper
-                      name="applicable_data_period"
+                      name="extensions[0].applicableDataPeriod"
                       label="Applicable Data Period"
                       required={false}
                     >
                       <Field
                         as="select"
-                        name="applicable_data_period"
-                        id="applicable_data_period"
+                        name="extensions[0].applicableDataPeriod"
+                        id="extensions[0].applicableDataPeriod"
                         value={convertPeriodLabelToApiValue(
-                          formik.values.applicable_data_period
+                          formik.values.extensions[0].applicableDataPeriod
                         )}
-                        onChange={formik.handleChange}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                          formik.setFieldValue(
+                            `extensions[0].applicableDataPeriod`,
+                            e.target.value
+                          );
+                          formik.setFieldValue(
+                            `extensions[0].currentExpectedDate`,
+                            submitterData?.data_periods?.find(
+                              (p) => p.data_period === e.target.value
+                            )?.expected_date
+                          );
+                        }}
                         onBlur={formik.handleBlur}
                       >
                         {submitterData?.data_periods?.map((item) => (
@@ -273,7 +244,7 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                         ))}
                       </Field>
                       <div className="help-text">
-                        Current: {currentExtension.applicable_data_period}
+                        Submitted: {currentExtension.applicable_data_period}
                       </div>
                     </FieldWrapper>
                   </Col>
@@ -295,14 +266,6 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
                       />
-                      <div className="help-text">
-                        Requested Target Date:{' '}
-                        {currentExtension.requested_target_date
-                          ? new Date(
-                              currentExtension.requested_target_date
-                            ).toLocaleDateString()
-                          : 'None'}
-                      </div>
                     </FieldWrapper>
                   </Col>
                   <Col md={3}>
@@ -361,6 +324,24 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
                     </FieldWrapper>
                   </Col>
                   <Col md={6}>
+                    <FieldWrapper
+                      name="justification"
+                      label="Justification"
+                      required={false}
+                    >
+                      <Field
+                        as="textarea"
+                        name="justification"
+                        id="justification"
+                        rows="5"
+                        maxLength="2000" // Set the maxLength attribute
+                        onChange={formik.handleChange}
+                        onBlur={formik.handleBlur}
+                      />
+                      <div className="help-text">2000 character limit</div>
+                    </FieldWrapper>
+                  </Col>
+                  <Col md={6}>
                     <FieldWrapper name="notes" label="Notes" required={false}>
                       <Field
                         as="textarea"
@@ -392,16 +373,6 @@ const EditExtensionModal: React.FC<EditExtensionModalProps> = ({
               </form>
             </FormikProvider>
           </QueryWrapper>
-          <hr />
-          <h4 className="modal-header">Current Extension Information</h4>
-          <div>
-            {extensionFields.map((field, index) => (
-              <Row key={index}>
-                <Col md={{ size: 4, offset: 1 }}>{field.label}:</Col>
-                <Col md={6}>{field.value}</Col>
-              </Row>
-            ))}
-          </div>
         </ModalBody>
       </Modal>
     </>

--- a/apcd_cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
+++ b/apcd_cms/src/client/src/components/Extensions/ViewExtensionModal/ViewExtensionModal.tsx
@@ -31,8 +31,12 @@ const ViewExtensionModal: React.FC<{
               </Col>
             </Row>
             <Row>
-              <Col md={{ size: 4, offset: 1 }}>Entity Organization</Col>
-              <Col md={7}>{extension.org_name}</Col>
+              <Col md={{ size: 4, offset: 1 }}>
+                Entity Organization - Payor Code
+              </Col>
+              <Col md={7}>
+                {extension.org_name} - {extension.payor_code}
+              </Col>
             </Row>
             <Row>
               <Col md={{ size: 4, offset: 1 }}>Requestor</Col>

--- a/apcd_cms/src/client/src/components/Submitter/Extensions/index.ts
+++ b/apcd_cms/src/client/src/components/Submitter/Extensions/index.ts
@@ -1,3 +1,4 @@
 import { ExtensionRequestForm } from './ExtensionsForm';
+import ExtensionFormInfo from './ExtensionFormInfo';
 
-export { ExtensionRequestForm };
+export { ExtensionRequestForm, ExtensionFormInfo };


### PR DESCRIPTION
## Overview

Updates to Extension Admin Edit modal

## Related

- [WP-924](https://tacc-main.atlassian.net/browse/WP-924)


## Changes

- Drops in ExtensionFormInfo to make more robust 
- Admin edit extension modal Refactors ExtensionFormInfo to accomodate both modal and extension form 
- Adds export of ExtensionFormInfo
- Updates Admin extension listing and view modal to show both entity org and payor code per stakeholder request

## Testing

1. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/) and create a new extension request with at least two different extensions
2. Go to [http://localhost:8000/administration/list-extensions/](http://localhost:8000/administration/list-extensions/) to make sure your submitted extensions appear in the admin listing
3. Check that payor code is next to entity org name in listing
4. Go to Actions --> Edit for your submitted extension
5. Change all fields and click submit
6. Make sure table and modal update with your new selections successfully.
7. Go to an different extension you did not create from the admin listing. Click Actions --> Edit
8. Change only a few fields and make sure it submits successfully.
9. Go to an extension Actions -- View
10. Make sure the payor code is next to the entity organization

## UI
### Edit Modal

![Screenshot 2025-06-03 at 4 33 47 PM](https://github.com/user-attachments/assets/35c84222-6587-4b3f-87c2-3918a49e137e)

### View Modal
![Screenshot 2025-06-03 at 4 49 38 PM](https://github.com/user-attachments/assets/9244c513-39a0-4d0a-af29-1a020b3e0435)

### Extension LIsting

![Screenshot 2025-06-03 at 4 49 18 PM](https://github.com/user-attachments/assets/57bea9b9-54dc-47ac-874a-dad9c21103b4)

<!--
## Notes

…
-->
