### PR TITLE
bug/extension-role-fix

### DIFF
--- a/apcd_cms/src/apps/common_api/views.py
+++ b/apcd_cms/src/apps/common_api/views.py
@@ -67,17 +67,15 @@ class cdlsView(APCDGroupAccessAPIMixin, BaseAPIView):
         return JsonResponse({"cdls": cdls_response})
 
 
-class DataPeriodsView(APCDSubmitterAdminAccessAPIMixin, BaseAPIView):
-    '''
-        Requires admin access to view data period for any given submitter.
-    '''
+class DataPeriodsView(APCDGroupAccessAPIMixin, BaseAPIView):
     def get(self, request, *args, **kwargs):
         submitter_id = request.GET.get('submitter_id', None)
         if submitter_id is None:
             raise Http404("Submitter Id not provided")
         if not is_apcd_admin(request.user):
-            # if user is not apcd admin, then submitter admin
-            # should have access to the submitter
+            # if user is not apcd admin, then submitter_id 
+            # must match only data periods with the same 
+            # submitter id
             submitters = apcd_database.get_submitter_info(request.user.username)
             if not any(submitter_id == str(submitter[0]) for submitter in submitters):
                 return JsonResponse({'error': f'Unauthorized for submitter id {submitter_id}'}, status=403)


### PR DESCRIPTION
## Overview
Updates mixin on common_api call to get applicable data periods


## Related

<!--
- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes

Removes AdminSubmitter mixin from the DataPeriodsView and allows any user with a APCD role (submitter_user, submitter_admin, apcd_admin)

## Testing

1. Go to [http://localhost:8000/admin/](http://localhost:8000/admin/) and set your role as a SUBMITTER_USER
2. Go to [http://localhost:8000/submissions/extension-request/](http://localhost:8000/submissions/extension-request/)
3. Make sure that the Applicable Data Periods populate after selecting a Business Name

## UI
### BEFORE FIX
![Screenshot 2025-06-25 at 3 43 42 PM](https://github.com/user-attachments/assets/e3aba3de-fa91-43ca-a317-1bc6996839ac)

### AFTER FIX
![Screenshot 2025-06-25 at 3 44 50 PM](https://github.com/user-attachments/assets/9dc3fccd-7b47-4afd-a182-018812645586)

…

<!--
## Notes

…
-->
