### PR TITLE
hotfix/Incorrect Heading for Exceptions Listing Page

### DIFF
--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/SubmitterExceptionList.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/SubmitterExceptionList.tsx
@@ -67,8 +67,8 @@ export const SubmitterExceptionList: React.FC = () => {
 
   return (
     <div className="container">
-      <h1>View Extension Requests</h1>
-      <p style={{ marginBottom: '30px' }}>Your submitted extension requests</p>
+      <h1>View Exception Requests</h1>
+      <p style={{ marginBottom: '30px' }}>Your submitted exception requests</p>
       <hr />
       <div className="filter-container">
         <div className="filter-content">


### PR DESCRIPTION
## Overview

Heading for List Exceptions page was incorrect.

## Changes

Minor text change, updated header and description to read Exceptions

## Testing

1. make sure the text is right on submissions/list-extensions and submissions/list-exceptions
