### PR TITLE
refactor: forget docker_repo.var

### DIFF
--- a/apcd_cms/Makefile
+++ b/apcd_cms/Makefile
@@ -1,4 +1,4 @@
-DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
+DOCKERHUB_REPO := taccwma/apcd-cms
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest


### PR DESCRIPTION
## Overview

Forget `docker_repo.var`. This CMS is alone in this repo, so explicitly name its Docker Hub repo.

> [!NOTE]
> Developers may delete `docker_hub.var`.

## Related

- mimics https://github.com/TACC/Core-CMS/pull/966
- similar to https://github.com/TACC/Core-CMS-Template/pull/10
- similar to https://github.com/TACC/Texascale-CMS/pull/20

## Changes

- **deletes** `docker_repo.var` reference and requirement

## Testing

**Meh.**

The only affected commands are `make build-full`, `make publish`, `make publish-latest`, but no one runs those, because we use GitHub Actions instead.