### PR TITLE
WP-937: Make Dropdowns More Consistent

### DIFF
--- a/apcd_cms/src/apps/admin_exception/templates/list_admin_exception.html
+++ b/apcd_cms/src/apps/admin_exception/templates/list_admin_exception.html
@@ -14,19 +14,4 @@
   <hr/>
   <div id="admin-exceptions-root"></div>
 </div>
-<script>
-
-      function openAction(exception_id) {
-      var actionsDropdown, selectedOption, modal_id;
-      actionsDropdown = document.getElementById(`actionsDropdown_${exception_id}`);
-      /* grabs dropdown option number selected by user via selectedIndex, 
-        then grabs actual value associated with that option via 
-        options[index].value */
-      selectedOption = actionsDropdown.options[actionsDropdown.selectedIndex].value;
-      modal_id = `${selectedOption}Modal_${exception_id}`;
-      $(`#${modal_id}`).modal({backdrop: "static"}); /* modal appears manually */
-    
-      actionsDropdown.selectedIndex = 0; /* resets dropdown to display 'Select Action' again */
-    }
-  </script>
 {% endblock %}

--- a/apcd_cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Exceptions/AdminExceptions.tsx
@@ -141,7 +141,7 @@ export const AdminExceptions: React.FC = () => {
                     className="status-filter"
                     onChange={(e) => openAction(e, row)}
                   >
-                    <option value="">Select Action</option>
+                    <option disabled value="">Select Action</option>
                     <option value="viewException">View Record</option>
                     <option value="editException">Edit Record</option>
                   </select>

--- a/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
+++ b/apcd_cms/src/client/src/components/Admin/Extensions/AdminExtensions.tsx
@@ -144,7 +144,7 @@ export const AdminExtensions: React.FC = () => {
                     className="status-filter"
                     onChange={(e) => openAction(e, row.ext_id)}
                   >
-                    <option value="">Select Action</option>
+                    <option disabled value="">Select Action</option>
                     <option value="viewExtension">View Record</option>
                     <option value="editExtension">Edit Record</option>
                   </select>

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
@@ -160,7 +160,7 @@ export const ViewUsers: React.FC = () => {
                       onChange={(event) => handleActionChange(event, user)}
                       value={dropdownValue}
                     >
-                      <option value="" disabled>
+                      <option disabled value="">
                         Select Action
                       </option>
                       <option value="view">View Record</option>

--- a/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -152,7 +152,7 @@ export const RegistrationList: React.FC<{
                     className="status-filter"
                     onChange={(e) => openAction(e, row.reg_id)}
                   >
-                    <option value="">Select Action</option>
+                    <option disabled value="">Select Action</option>
                     <option value="viewRegistration">View Record</option>
                     {isAdmin ? (
                       <option value="editRegistration">Edit Record</option>

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionForm.tsx
@@ -86,7 +86,7 @@ export const ExceptionForm: React.FC<{
               name={`exceptions[${index}].businessName`}
               id={`exceptions[${index}].businessName`}
             >
-              <option value="">Select a Business Name</option>
+              <option disabled value="">Select a Business Name</option>
               {submitterData?.submitters?.map((submitter: Entities) => (
                 <option
                   value={submitter.submitter_id}
@@ -123,7 +123,7 @@ export const ExceptionForm: React.FC<{
                 setFieldValue(`exceptions[${index}].fieldCode`, '');
               }}
             >
-              <option value="">Select a File Type</option>
+              <option disabled value="">Select a File Type</option>
               <option value="dc">Dental Claims</option>
               <option value="mc">Medical Claims</option>
               <option value="me">Member Eligibility</option>
@@ -151,7 +151,7 @@ export const ExceptionForm: React.FC<{
             >
               {cdlData ? (
                 <>
-                  <option value="">Select Field Code</option>
+                  <option disabled value="">Select Field Code</option>
                   {cdlData.cdls.map((cdl: any) => (
                     <option
                       key={cdl.field_list_code}
@@ -165,7 +165,7 @@ export const ExceptionForm: React.FC<{
                   ))}
                 </>
               ) : (
-                <option value="">Select a File Type Above First</option>
+                <option disabled value="">Select a File Type Above First</option>
               )}
             </Field>
           </FieldWrapper>

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -237,7 +237,7 @@ export const ExceptionFormPage: React.FC = () => {
                       setIsSuccess(false);
                     }}
                   >
-                    <option value="">-- Select Exception Type --</option>
+                    <option disabled value="">Select Exception Type</option>
                     <option value="threshold">Threshold Exception</option>
                     <option value="other">Other Exception</option>
                   </Field>

--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/SubmitterExceptionList.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/SubmitterExceptionList.tsx
@@ -139,7 +139,7 @@ export const SubmitterExceptionList: React.FC = () => {
                     className="status-filter"
                     onChange={(e) => openAction(e, row)}
                   >
-                    <option value="">Select Action</option>
+                    <option disabled value="">Select Action</option>
                     <option value="viewException">View Record</option>
                   </select>
                 </td>

--- a/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionFormInfo.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Extensions/ExtensionFormInfo.tsx
@@ -71,7 +71,7 @@ const ExtensionFormInfo: React.FC<{
                     );
                   }}
                 >
-                  <option value="">Select Business Name</option>
+                  <option disabled value="">Select Business Name</option>
                   {submitterData?.submitters?.map((submitter: Entities) => (
                     <option
                       value={submitter.submitter_id}
@@ -109,7 +109,7 @@ const ExtensionFormInfo: React.FC<{
           name={`extensions.[${index}].extensionType`}
           id={`extensions.[${index}].extensionType`}
         >
-          <option value="">Select Extension Type</option>
+          <option disabled value="">Select Extension Type</option>
           <option value="regular">Regularly Scheduled Submission</option>
           <option value="resubmission">Corrected Resubmission</option>
           <option value="small_carrier">
@@ -149,7 +149,7 @@ const ExtensionFormInfo: React.FC<{
                 );
               }}
             >
-              <option value="">-- Select period --</option>
+              <option disabled value="">Select period</option>
               {dataPeriods.map((item) => (
                 <option value={item.data_period} key={item.data_period}>
                   {item.data_period}

--- a/apcd_cms/src/client/src/components/Submitter/Extensions/SubmitterExtensionList.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Extensions/SubmitterExtensionList.tsx
@@ -134,7 +134,7 @@ export const SubmitterExtensionList: React.FC = () => {
                     className="status-filter"
                     onChange={(e) => openAction(e, row.ext_id)}
                   >
-                    <option value="">Select Action</option>
+                    <option disabled value="">Select Action</option>
                     <option value="viewExtension">View Record</option>
                   </select>
                 </td>


### PR DESCRIPTION
## Overview

Updated dropdowns to be more consistent looking. 

## Related

- [WP-937](https://tacc-main.atlassian.net/browse/WP-937)

## Changes

Added disabled attribute to non-selectable default dropdown options where applicable. 

## Testing

1. Check the dropdowns on listing, edit pages to verify they look consistent. 

## Notes

I had to update my local dev Dockerfile to core-cms tag 4.35.0 (latest from Wes) in order to build locally. The debian repo was returning 404s and the update to the debian version in the new core-cms release resolved this. I REMOVED this change for the pull request since I think we should have a separate task for it but please note you may need to do this if your local dev fails to build while testing. 
