### PR TITLE
bug/wp-1042-Exception-form-business-name-error

### DIFF
--- a/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/Exceptions/ExceptionFormPage.tsx
@@ -14,7 +14,8 @@ import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
 interface FormValues {
   exceptionType: string;
   exceptions: {
-    businessName: number;
+    // Business name initial value is a blank string but needs to submit as a number
+    businessName: number | string;
     fileType: string;
     fieldCode: string;
     expiration_date: string;
@@ -93,7 +94,7 @@ export const ExceptionFormPage: React.FC = () => {
   const initialValues: FormValues = {
     exceptionType: selectedExceptionType ? selectedExceptionType : '',
     exceptions: Array.from({ length: numberOfExceptionBlocks }).map(() => ({
-      businessName: 0,
+      businessName: '',
       fileType: '',
       fieldCode: '',
       expiration_date: '',
@@ -237,7 +238,9 @@ export const ExceptionFormPage: React.FC = () => {
                       setIsSuccess(false);
                     }}
                   >
-                    <option disabled value="">Select Exception Type</option>
+                    <option disabled value="">
+                      Select Exception Type
+                    </option>
                     <option value="threshold">Threshold Exception</option>
                     <option value="other">Other Exception</option>
                   </Field>


### PR DESCRIPTION
## Overview
Address business name field bug on exception form

## Related

- [WP-1042](https://tacc-main.atlassian.net/browse/WP-1042)

## Changes
Addresses type mismatch between initial set value (number) and the default value (string) causing the field to show an error 

## Testing

1. Go to [http://localhost:8000/submissions/exception/](http://localhost:8000/submissions/exception/)
2. Select Threshold
3. Ensure that Select Business Name is in the business name drop down on load. 
4. Click the Add Exception button
5. Ensure that Select Business Name is in the business name drop down on load of the new exception block
6. Try to submit without selecting a Business name and make sure the error displays correctly
7. Try to submit after selecting a business name and make sure field error no longer appears
8. Fill out entire form with two exceptions and make sure it successfully submits. Check exception admin table to make sure it looks correct.

## UI

…

<!--
## Notes

…
-->
