### PR TITLE
Registration Delinquency DB Function

### DIFF
--- a/apcd_cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd_cms/src/apps/submitter_renewals_listing/views.py
@@ -1,5 +1,5 @@
 from django.http import JsonResponse
-from apps.utils.apcd_database import get_registrations, get_registration_contacts, get_registration_entities
+from apps.utils.apcd_database import get_registrations, get_registration_contacts, get_registration_entities, get_user_delinquent
 from django.views.generic.base import TemplateView
 from apps.admin_regis_table.utils import get_registration_list_json
 from apps.base.base import BaseAPIView, APCDSubmitterAdminAccessAPIMixin, APCDSubmitterAdminAccessTemplateMixin
@@ -38,6 +38,9 @@ class SubmittersApi(APCDSubmitterAdminAccessAPIMixin, BaseAPIView):
             return JsonResponse({'response': _set_registration(registration, registrations_entities, registrations_contacts)})
         else:
             registration_list = get_registrations(submitter_codes=submitter_codes)
+            # TODO this is only demonstrating the function working, needs to be intengrated into the app somehow!
+            is_delinquent = get_user_delinquent(request.user.username)
+            print("Is User " + request.user.username + " registration delinquent: " + str(is_delinquent))
             for registration in registration_list:
                 registrations_content.append(registration)
             try:

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1463,6 +1463,39 @@ def update_exception(form):
         if conn is not None:
             conn.close()
 
+def get_user_delinquent(user_id):
+    cur = None
+    conn = None
+    try:
+        with db_connect() as conn:
+            cur = conn.cursor()
+            cur = conn.cursor()
+
+            current_year = datetime.now().year
+            query = """
+            select max(registration_year) from registrations 
+            left join submitters on submitters.registration_id = registrations.registration_id 
+            left join submitter_users on submitter_users.submitter_id = submitters.submitter_id 
+            where user_id = %s
+            """
+            cur.execute(query, (user_id,))
+            reg_year = cur.fetchone()
+            if reg_year[0] != None and reg_year[0] < current_year:
+                return True
+            elif reg_year[0] == None:
+                # if the reg year is empty in production this is a case of bad data and shouldn't happen, but covering our bases
+                return True
+            else:
+                return False
+
+    except Exception as error:
+        logger.error(error)
+
+    finally:
+        if cur is not None:
+            cur.close()
+        if conn is not None:
+            conn.close()
 def _acceptable_entity(form, iteration, reg_id=None):
     str_end = f'{iteration}{ f"_{reg_id}" if reg_id else "" }'
     required_keys = [


### PR DESCRIPTION
This adds a query to check the registration delinquency if a user to help with David's new feature. 

## Overview

This adds a small function that returns TRUE if user has no registrations with the current year OR if they have no registration date listed at all (this is to cover data issues), or FALSE if they have a current year registration. I also added a debug statement to the submitter registration listing page just to demonstrate usage and show that it works (hard to test otherwise!). Just noting here since it should probably be removed once the feature is fully implemented. 

## Related

[WP-912](https://tacc-main.atlassian.net/browse/WP-912)

## Changes

Added query to apcd_database and print debug to submitter_renewals_listing/views.py. The debug will only show up in django logs.

## Testing

1. Navigate to register/list-registration-requests/ and check in django logs to see: 
Is User <your username> reg delenquent: <True or False>  

## UI

…

<!--
## Notes

…
-->
