### PR TITLE
Task/user query banner addon

### DIFF
--- a/apcd_cms/package-lock.json
+++ b/apcd_cms/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "apcd_cms",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/apcd_cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd_cms/src/apps/submitter_renewals_listing/views.py
@@ -1,5 +1,5 @@
 from django.http import JsonResponse
-from apps.utils.apcd_database import get_registrations, get_registration_contacts, get_registration_entities
+from apps.utils.apcd_database import get_registrations, get_registration_contacts, get_registration_entities, get_user_delinquent
 from django.views.generic.base import TemplateView
 from apps.admin_regis_table.utils import get_registration_list_json
 from apps.base.base import BaseAPIView, APCDSubmitterAdminAccessAPIMixin, APCDSubmitterAdminAccessTemplateMixin
@@ -38,6 +38,9 @@ class SubmittersApi(APCDSubmitterAdminAccessAPIMixin, BaseAPIView):
             return JsonResponse({'response': _set_registration(registration, registrations_entities, registrations_contacts)})
         else:
             registration_list = get_registrations(submitter_codes=submitter_codes)
+            # TODO this is only demonstrating the function working, needs to be intengrated into the app somehow!
+            is_delinquent = get_user_delinquent(request.user.username)
+            print("Is User " + request.user.username + " registration delinquent: " + str(is_delinquent))
             for registration in registration_list:
                 registrations_content.append(registration)
             try:

--- a/apcd_cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd_cms/src/apps/submitter_renewals_listing/views.py
@@ -41,6 +41,14 @@ class SubmittersApi(APCDSubmitterAdminAccessAPIMixin, BaseAPIView):
             # TODO this is only demonstrating the function working, needs to be intengrated into the app somehow!
             is_delinquent = get_user_delinquent(request.user.username)
             print("Is User " + request.user.username + " registration delinquent: " + str(is_delinquent))
+            # Build banner for frontend
+            banner = None
+            if is_delinquent:
+                banner = {
+                    "level": "warning",
+                    "code": "DELINQUENT",
+                    "text": "Your registration is delinquent. Please renew."
+                }
             for registration in registration_list:
                 registrations_content.append(registration)
             try:
@@ -51,5 +59,8 @@ class SubmittersApi(APCDSubmitterAdminAccessAPIMixin, BaseAPIView):
                                                        request.GET.get('org'), page_num, *args, **kwargs)
             response_json['header'] = ['Business Name', 'Year', 'Created', 'Registration Status', 'Actions']
             response_json['pagination_url_namespaces'] = 'register:submitter_regis_table'
+            # Attach banner + delinquency flag
+            response_json['banner'] = banner
+            response_json['is_delinquent'] = bool(is_delinquent)
             return JsonResponse({'response': response_json})
 

--- a/apcd_cms/src/apps/utils/apcd_database.py
+++ b/apcd_cms/src/apps/utils/apcd_database.py
@@ -1463,6 +1463,39 @@ def update_exception(form):
         if conn is not None:
             conn.close()
 
+def get_user_delinquent(user_id):
+    cur = None
+    conn = None
+    try:
+        with db_connect() as conn:
+            cur = conn.cursor()
+            cur = conn.cursor()
+
+            current_year = datetime.now().year
+            query = """
+            select max(registration_year) from registrations 
+            left join submitters on submitters.registration_id = registrations.registration_id 
+            left join submitter_users on submitter_users.submitter_id = submitters.submitter_id 
+            where user_id = %s
+            """
+            cur.execute(query, (user_id,))
+            reg_year = cur.fetchone()
+            if reg_year[0] != None and reg_year[0] < current_year:
+                return True
+            elif reg_year[0] == None:
+                # if the reg year is empty in production this is a case of bad data and shouldn't happen, but covering our bases
+                return True
+            else:
+                return False
+
+    except Exception as error:
+        logger.error(error)
+
+    finally:
+        if cur is not None:
+            cur.close()
+        if conn is not None:
+            conn.close()
 def _acceptable_entity(form, iteration, reg_id=None):
     str_end = f'{iteration}{ f"_{reg_id}" if reg_id else "" }'
     required_keys = [

--- a/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -11,6 +11,36 @@ import {
   useSubmitterRegistration,
 } from 'hooks/registrations';
 
+/** Banner types and helpers **/
+type BannerLevel = 'info' | 'success' | 'warning' | 'danger';
+type Banner = { level?: BannerLevel; text: string; code?: string };
+
+const bannerClass = (level?: BannerLevel) => {
+  switch (level) {
+    case 'success':
+      return 'c-message c-message--success';
+    case 'warning':
+      return 'c-message c-message--warning';
+    case 'danger':
+      return 'c-message c-message--error';
+    default:
+      return 'c-message c-message--info';
+  }
+};
+
+const MessageBanner: React.FC<{ banner?: Banner | null }> = ({ banner }) => {
+  if (!banner?.text) return null;
+  return (
+    <div
+      className={bannerClass(banner.level)}
+      role="alert"
+      style={{ marginBottom: 12 }}
+    >
+      {banner.text}
+    </div>
+  );
+};
+
 export const RegistrationList: React.FC<{
   useDataHook: any;
   isAdmin?: boolean;
@@ -85,123 +115,118 @@ export const RegistrationList: React.FC<{
   };
 
   return (
-    <div>
-      <div className="filter-container">
-        <div className="filter-content">
-          {/* Filter */}
-          <span>
-            <b>Filter by Status: </b>
-          </span>
-          <select
-            id="statusFilter"
-            className="status-filter"
-            value={status}
-            onChange={(e) => setStatus(e.target.value)}
-          >
-            {data?.status_options.map((status, index) => (
-              <option className="dropdown-text" key={index} value={status}>
-                {status}
-              </option>
-            ))}
-          </select>
+  <div>
+    {/* Show server-provided delinquency banner if present */}
+    <MessageBanner banner={data?.banner as Banner | undefined} />
 
-          <span>
-            <b>Filter by Organization: </b>
-          </span>
-          <select
-            id="organizationFilter"
-            className="status-filter org-filter"
-            value={org}
-            onChange={(e) => setOrg(e.target.value)}
-          >
-            {data?.org_options.map((org, index) => (
-              <option className="dropdown-text" key={index} value={org}>
-                {org}
-              </option>
-            ))}
-          </select>
-          {data?.selected_status !== initStateFilter || data?.selected_org ? (
-            <ClearOptionsButton onClick={clearSelections} />
-          ) : null}
-        </div>
+    <div className="filter-container">
+      <div className="filter-content">
+        {/* Filter */}
+        <span><b>Filter by Status: </b></span>
+        <select
+          id="statusFilter"
+          className="status-filter"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          {data?.status_options.map((status, index) => (
+            <option className="dropdown-text" key={index} value={status}>
+              {status}
+            </option>
+          ))}
+        </select>
+
+        <span><b>Filter by Organization: </b></span>
+        <select
+          id="organizationFilter"
+          className="status-filter org-filter"
+          value={org}
+          onChange={(e) => setOrg(e.target.value)}
+        >
+          {data?.org_options.map((org, index) => (
+            <option className="dropdown-text" key={index} value={org}>
+              {org}
+            </option>
+          ))}
+        </select>
+
+        {data?.selected_status !== initStateFilter || data?.selected_org ? (
+          <ClearOptionsButton onClick={clearSelections} />
+        ) : null}
       </div>
-      <table id="registrationTable" className="registration-table">
-        <thead>
-          <tr>
-            {data?.header.map((columnName: string, index: number) => (
-              <th key={index}>{columnName}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data?.page && data.page.length > 0 ? (
-            data?.page.map((row: RegistrationRow, rowIndex: number) => (
-              <tr key={rowIndex}>
-                <td>{row.biz_name}</td>
-                <td>{row.year ? row.year : 'None'}</td>
-                <td>
-                  {row.posted_date
-                    ? new Date(row.posted_date).toLocaleString()
-                    : '—'}
-                </td>
-                <td>{row.reg_status ? row.reg_status : 'None'}</td>
-                <td>
-                  <select
-                    id={`actionsDropdown_${row.reg_id}`}
-                    defaultValue=""
-                    className="status-filter"
-                    onChange={(e) => openAction(e, row.reg_id)}
-                  >
-                    <option disabled value="">Select Action</option>
-                    <option value="viewRegistration">View Record</option>
-                    {isAdmin ? (
-                      <option value="editRegistration">Edit Record</option>
-                    ) : (
-                      <option value="renewRegistration">
-                        Renew Registration
-                      </option>
-                    )}
-                  </select>
-                </td>
-              </tr>
-            ))
-          ) : (
-            <tr>
-              <td colSpan={data.header.length} style={{ textAlign: 'center' }}>
-                No Data available
+    </div>
+
+    <table id="registrationTable" className="registration-table">
+      <thead>
+        <tr>
+          {data?.header.map((columnName: string, index: number) => (
+            <th key={index}>{columnName}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data?.page && data.page.length > 0 ? (
+          data.page.map((row: RegistrationRow, rowIndex: number) => (
+            <tr key={rowIndex}>
+              <td>{row.biz_name}</td>
+              <td>{row.year ? row.year : 'None'}</td>
+              <td>
+                {row.posted_date ? new Date(row.posted_date).toLocaleString() : '—'}
+              </td>
+              <td>{row.reg_status ? row.reg_status : 'None'}</td>
+              <td>
+                <select
+                  id={`actionsDropdown_${row.reg_id}`}
+                  defaultValue=""
+                  className="status-filter"
+                  onChange={(e) => openAction(e, row.reg_id)}
+                >
+                  <option disabled value="">Select Action</option>
+                  <option value="viewRegistration">View Record</option>
+                  {isAdmin ? (
+                    <option value="editRegistration">Edit Record</option>
+                  ) : (
+                    <option value="renewRegistration">Renew Registration</option>
+                  )}
+                </select>
               </td>
             </tr>
-          )}
-        </tbody>
-      </table>
-      <div className={styles.paginatorContainer}>
-        <Paginator
-          pages={data?.total_pages ?? 0}
-          current={data?.page_num ?? 0}
-          callback={setPage}
-        />
-      </div>
-      {selectedRegistration && (
-        <>
-          <ViewRegistrationModal
-            reg_id={selectedRegistration.reg_id}
-            isVisible={isViewModalOpen}
-            useDataHook={
-              isAdmin ? useAdminRegistration : useSubmitterRegistration
-            }
-            onClose={() => setIsViewModalOpen(false)}
-          />
-          <EditRegistrationModal
-            reg_id={selectedRegistration.reg_id}
-            isVisible={isEditModalOpen}
-            useDataHook={
-              isAdmin ? useAdminRegistration : useSubmitterRegistration
-            }
-            status_options={data?.status_options as string[]}
-            onClose={() => setIsEditModalOpen(false)}
-          />
-        </>
-      )}
+          ))
+        ) : (
+          <tr>
+            <td colSpan={data.header.length} style={{ textAlign: 'center' }}>
+              No Data available
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+
+    <div className={styles.paginatorContainer}>
+      <Paginator
+        pages={data?.total_pages ?? 0}
+        current={data?.page_num ?? 0}
+        callback={setPage}
+      />
     </div>
+
+    {selectedRegistration && (
+      <>
+        <ViewRegistrationModal
+          reg_id={selectedRegistration.reg_id}
+          isVisible={isViewModalOpen}
+          useDataHook={isAdmin ? useAdminRegistration : useSubmitterRegistration}
+          onClose={() => setIsViewModalOpen(false)}
+        />
+        <EditRegistrationModal
+          reg_id={selectedRegistration.reg_id}
+          isVisible={isEditModalOpen}
+          useDataHook={isAdmin ? useAdminRegistration : useSubmitterRegistration}
+          status_options={data?.status_options as string[]}
+          onClose={() => setIsEditModalOpen(false)}
+        />
+      </>
+    )}
+  </div>
   );
-};
+}

--- a/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -34,7 +34,7 @@ const MessageBanner: React.FC<{ banner?: Banner | null }> = ({ banner }) => {
     <div
       className={bannerClass(banner.level)}
       role="alert"
-      style={{ marginBottom: 12 }}
+      style={{ marginBottom: 12, fontSize: '1.1em', border: '2px solid, rgb(205, 151, 28)', padding: '10px', backgroundColor: 'rgb(253, 240, 211)'}}
     >
       {banner.text}
     </div>


### PR DESCRIPTION
## Overview

…
Changes primarily to RegistrationsList.tsx and submitter_renewals_listing. I branched off Carrie's task/deliquent-user-query
## Related

<!--
- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
 backend flag returns a banner message when the user is delinquent, and updated the React list component to conditionally render that banner if the message is present.
…

## Testing

1. Go to http://localhost:8000/register/list-registration-requests/ and see if banner visible.

## UI

…

<!--
## Notes

…this is based off of Carrie's work here, https://github.com/TACC/APCD-CMS/pull/24 which i built upon. I'm not sure how to test if delinquent flag not there. will banner go away if database indicates user not delinquent
-->
