### PR TITLE
Use formatDate util for registrations listings

### DIFF
--- a/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/RegistrationList/RegistrationList.tsx
@@ -6,6 +6,7 @@ import ViewRegistrationModal from 'apcd-components/Registrations/ViewRegistratio
 import EditRegistrationModal from 'apcd-components/Registrations/EditRegistrationModal/EditRegistrationModal';
 import styles from './RegistrationList.module.css';
 import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
+import { formatDate } from 'utils/dateUtil';
 import {
   useAdminRegistration,
   useSubmitterRegistration,
@@ -141,7 +142,7 @@ export const RegistrationList: React.FC<{
                 <td>{row.year ? row.year : 'None'}</td>
                 <td>
                   {row.posted_date
-                    ? new Date(row.posted_date).toLocaleString()
+                    ? formatDate(row.posted_date)
                     : '—'}
                 </td>
                 <td>{row.reg_status ? row.reg_status : 'None'}</td>


### PR DESCRIPTION
## Overview

…

## Related

<!--
- [WP-123](https://tacc-main.atlassian.net/browse/WP-123)
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- To be consistent with other listings, use the `formatDate` util for formatting the created at date for registrations listings
…

## Testing

1. Confirm that no seconds are displayed in the 'Created' column for the Admin and Submitter registrations listings
2. Submit a new registration and confirm new record shows the same as above

## UI

…

<!--
## Notes

…
-->
