### PR TITLE
task: Update new medicare field usage with deploy date setting

### DIFF
--- a/apcd_cms/src/apps/admin_regis_table/views.py
+++ b/apcd_cms/src/apps/admin_regis_table/views.py
@@ -1,5 +1,6 @@
 from django.http import JsonResponse
 from django.views.generic.base import TemplateView
+from django.conf import settings
 from apps.utils.apcd_database import (
     delete_registration_entity,
     delete_registration_contact,
@@ -24,6 +25,8 @@ from apps.base.base import (
 )
 import logging
 import json
+
+MEDICARE_UPDATE_DEPLOY_DATE = getattr(settings, 'MEDICARE_UPDATE_DEPLOY_DATE', '')
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +117,10 @@ class RegistrationsApi(APCDAdminAccessAPIMixin, BaseAPIView):
             registration = self._get_first_registration_entry(reg_id)
             registrations_entities = get_registration_entities(reg_id=reg_id)
             registrations_contacts = get_registration_contacts(reg_id=reg_id)
-            return JsonResponse({'response': _set_registration(registration, registrations_entities, registrations_contacts)})
+            formatted_reg_data = _set_registration(registration, registrations_entities, registrations_contacts)
+
+            context = {'registration_data': formatted_reg_data, 'medicare_date': MEDICARE_UPDATE_DEPLOY_DATE}
+            return JsonResponse({'response': context})
         else:
             registrations_content = get_registrations()
             try:

--- a/apcd_cms/src/apps/registrations/views.py
+++ b/apcd_cms/src/apps/registrations/views.py
@@ -19,8 +19,6 @@ RT_UN = getattr(settings, 'RT_UN', '')
 RT_PW = getattr(settings, 'RT_PW', '')
 RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
 MEDICARE_UPDATE_DEPLOY_DATE = getattr(settings, 'MEDICARE_UPDATE_DEPLOY_DATE', '')
-logger.error('medicare date:')
-logger.error(MEDICARE_UPDATE_DEPLOY_DATE)
 
 
 class RegistrationFormTemplate(AuthenticatedUserTemplateMixin, TemplateView):

--- a/apcd_cms/src/apps/registrations/views.py
+++ b/apcd_cms/src/apps/registrations/views.py
@@ -18,6 +18,9 @@ RT_HOST = getattr(settings, 'RT_HOST', '')
 RT_UN = getattr(settings, 'RT_UN', '')
 RT_PW = getattr(settings, 'RT_PW', '')
 RT_QUEUE = getattr(settings, 'RT_QUEUE', '')
+MEDICARE_UPDATE_DEPLOY_DATE = getattr(settings, 'MEDICARE_UPDATE_DEPLOY_DATE', '')
+logger.error('medicare date:')
+logger.error(MEDICARE_UPDATE_DEPLOY_DATE)
 
 
 class RegistrationFormTemplate(AuthenticatedUserTemplateMixin, TemplateView):
@@ -42,7 +45,7 @@ class RegistrationFormApi(AuthenticatedUserAPIMixin, BaseAPIView):
             formatted_reg_data = _set_registration(registration_content, registration_entities, registration_contacts)
 
         if (request.user.is_authenticated and has_apcd_group(request.user)):
-            context = {'registration_data': formatted_reg_data, 'renew': renew}
+            context = {'registration_data': formatted_reg_data, 'renew': renew, 'medicare_date': MEDICARE_UPDATE_DEPLOY_DATE}
             return JsonResponse({'response': context})
         else: 
             return JsonResponse({'error': 'Unauthorized'}, status=403)

--- a/apcd_cms/src/apps/submitter_renewals_listing/views.py
+++ b/apcd_cms/src/apps/submitter_renewals_listing/views.py
@@ -1,12 +1,15 @@
 from django.http import JsonResponse
 from apps.utils.apcd_database import get_registrations, get_registration_contacts, get_registration_entities
 from django.views.generic.base import TemplateView
+from django.conf import settings
 from apps.admin_regis_table.utils import get_registration_list_json
 from apps.base.base import BaseAPIView, APCDSubmitterAdminAccessAPIMixin, APCDSubmitterAdminAccessTemplateMixin
 from apps.utils.registrations_data_formatting import _set_registration
 from apps.submitter_renewals_listing.utils import get_submitter_codes
 import logging
 import json
+
+MEDICARE_UPDATE_DEPLOY_DATE = getattr(settings, 'MEDICARE_UPDATE_DEPLOY_DATE', '')
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +38,10 @@ class SubmittersApi(APCDSubmitterAdminAccessAPIMixin, BaseAPIView):
             registration = self._get_first_registration_entry(submitter_codes=submitter_codes, reg_id=reg_id)
             registrations_entities = get_registration_entities(reg_id=reg_id)
             registrations_contacts = get_registration_contacts(reg_id=reg_id)
-            return JsonResponse({'response': _set_registration(registration, registrations_entities, registrations_contacts)})
+            formatted_reg_data = _set_registration(registration, registrations_entities, registrations_contacts)
+
+            context = {'registration_data': formatted_reg_data, 'medicare_date': MEDICARE_UPDATE_DEPLOY_DATE}
+            return JsonResponse({'response': context})
         else:
             registration_list = get_registrations(submitter_codes=submitter_codes)
             for registration in registration_list:

--- a/apcd_cms/src/client/src/components/Forms/Registrations/FormEntity.tsx
+++ b/apcd_cms/src/client/src/components/Forms/Registrations/FormEntity.tsx
@@ -5,17 +5,17 @@ import { TextFormField } from './TextFormField';
 import styles from './RegistrationForm.module.css';
 import FieldWrapper from 'core-wrappers/FieldWrapperFormik';
 
-const getPayorTypes = (posted_date: Date | null) => {
-  // UTHealth's registration year begins Oct 1 of the previous year
-  // ex. reg year 2026 will begin 10/01/2025, so allow 2026 starting that day
-  const sep15_25 = new Date(`2025-09-15 0:00:00`);
-  if (posted_date && new Date(posted_date) < sep15_25) {
+const getPayorTypes = (posted_date: Date | null, medicare_date: string) => {
+  // new medicare fields introduced to form Oct 2025; we retain the previously used 'Medicare' field for
+  // records created prior to these new fields being deployed
+  const medicare_deploy_date = new Date(medicare_date);
+  if (posted_date && new Date(posted_date) < medicare_deploy_date) {
     return ['Commercial', 'Medicare', 'Medicaid'];
   }
   return ['Commercial', 'Medicare_Advantage', 'Medicare_Supplementary', 'Medicaid'];
 }
 
-export const RegistrationEntity: React.FC<{ index: number, posted_date: Date | null, isEdit: boolean }> = ({ index, posted_date, isEdit }) => {
+export const RegistrationEntity: React.FC<{ index: number, posted_date: Date | null, isEdit: boolean, medicare_date: string }> = ({ index, posted_date, isEdit, medicare_date }) => {
   return (
     <div>
       <h5 className={`${styles.boldedHeader} ${styles.spacedHeader}`}>
@@ -69,7 +69,7 @@ export const RegistrationEntity: React.FC<{ index: number, posted_date: Date | n
           className="checkboxselectmultiple"
           id={`entities.${index}.types_of_payors`}
         >
-          {getPayorTypes(posted_date).map((payorType) => (
+          {getPayorTypes(posted_date, medicare_date).map((payorType) => (
             <FormGroup
               key={`entities.${index}.types_of_payors_${payorType.toLowerCase()}.wrapper`}
               noMargin={true}

--- a/apcd_cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
+++ b/apcd_cms/src/client/src/components/Forms/Registrations/RegistrationForm.tsx
@@ -137,6 +137,7 @@ const initialValues: RegistrationFormValues = {
   state: 'AL',
   zip_code: '',
   reg_id: -1,
+  medicare_date: '',
   entities: [
     {
       entity_name: '',
@@ -287,7 +288,8 @@ export const RegistrationForm: React.FC<{
           initialValues={
             data && isEdit
               ? transformToRegistrationFormValues( // use initialValues to preload data for edit registration
-                  data['registration_data']        // to leverage formik's dirty test and disable submit on form load
+                  data['registration_data'],        // to leverage formik's dirty test and disable submit on form load
+                  data['medicare_date'],
                 )
               : inputValues ?? initialValues
           }
@@ -305,6 +307,7 @@ export const RegistrationForm: React.FC<{
               if (data && !isEdit) {
                 setValues(transformToRegistrationFormValues(
                   data['registration_data'],
+                  data['medicare_date'],
                   data['renew']
                 ));
               }
@@ -450,8 +453,14 @@ export const RegistrationForm: React.FC<{
                     (If single company, enter the same organization as above.)
                   </small>
                 </h4>
+                {console.log(values)}
                 {values.entities.map((entity, index) => (
-                  <RegistrationEntity key={index} index={index} posted_date={values.posted_date && isEdit ? values.posted_date : null} isEdit={isEdit} />
+                  <RegistrationEntity 
+                    key={index}
+                    index={index}
+                    posted_date={values.posted_date && isEdit ? values.posted_date : null}
+                    isEdit={isEdit}
+                    medicare_date={values.medicare_date} />
                 ))}
                 {values.entities.length === 5 && (
                   <p className="c-message c-message--type-info c-message--scope-inline">

--- a/apcd_cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/EditRegistrationModal/EditRegistrationModal.tsx
@@ -20,7 +20,7 @@ const EditRegistrationModal: React.FC<{
   if (!data) return <div>No data Found.</div>;
 
   const form_values: RegistrationFormValues =
-    transformToRegistrationFormValues(data);
+    transformToRegistrationFormValues(data['registration_data'], data['medicare_date']);
 
   const closeBtn = (
     <button className="close" onClick={onClose} type="button">

--- a/apcd_cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
+++ b/apcd_cms/src/client/src/components/Registrations/ViewRegistrationModal/ViewRegistrationModal.tsx
@@ -26,7 +26,7 @@ const ViewRegistrationModal: React.FC<{
     status,
     entities,
     contacts,
-  } = data;
+  } = data['registration_data'];
 
   const closeBtn = (
     <button className="close" onClick={onClose} type="button">

--- a/apcd_cms/src/client/src/hooks/registrations/index.ts
+++ b/apcd_cms/src/client/src/hooks/registrations/index.ts
@@ -1,6 +1,7 @@
 export type RegFormData = {
   registration_data: RegistrationContent;
   renew: boolean;
+  medicare_date: string;
 };
 
 export { useRegFormData, usePostRegistration } from './useForm';
@@ -82,6 +83,7 @@ export type RegistrationFormValues = {
   reg_id?: number;
   reg_status?: string;
   posted_date?: Date;
+  medicare_date: string;
   entities: {
     entity_name: string;
     fein: string;
@@ -116,7 +118,8 @@ export type RegistrationFormValues = {
 
 export function transformToRegistrationFormValues(
   registration: RegistrationContent,
-  renew?: boolean | undefined
+  medicare_date: string,
+  renew?: boolean | undefined,
 ): RegistrationFormValues {
   const typeValueMap: Record<string, string> = {
     // to set database value for field rather than display value
@@ -136,6 +139,7 @@ export function transformToRegistrationFormValues(
     reg_id: registration.reg_id,
     reg_status: registration.status,
     posted_date: registration.posted_date,
+    medicare_date: medicare_date,
     entities: registration.entities.map((entity) => ({
       entity_name: entity.ent_name,
       fein: entity.fein ?? '',


### PR DESCRIPTION
## Overview
UTHealth wants to use new Medicare Advantage + Medicare Supplementary fields and retain old Medicare field, effective date of switch being the date the feature deploys; updates the check for using new vs old fields to use setting rather than hardcoded value
…

## Related

- [WP-1045](https://tacc-main.atlassian.net/browse/WP-1045)
<!--
- requires https://github.com/TACC/Core-CMS/pull/117
-->…

## Changes
- Updates views for both admin and submitter reg listings + reg form to read new setting `MEDICARE_UPDATE_DEPLOY_DATE`
- Updates frontend registration types to store this medicare date
- Updates payor type check in registration entity component to compare the record's `posted_date` to this deploy setting
…

## Testing

1. Add the variable `MEDICARE_UPDATE_DEPLOY_DATE` to your local secrets.py file and set the value to `datetime(2025,10,1)`, (**also add `from datetime import datetime` to top of secrets file**) then stop, rebuild, and restart your containers.
2. Go to http://localhost:8000/register/request-to-submit/ and confirm that new fields 'Medicare Advantage' and 'Medicare Supplementary' appear under Entity Being Registered -> Payor Types
3. Fill out form and confirm successful form submission
4. Go to http://localhost:8000/administration/list-registration-requests/ and confirm your new record appears and has all correct info in the listing, view, and edit modals (expect to see new fields, not old Medicare field in edit modal)
5. For another listing item with a `Created` date prior to October 1, 2025, confirm view and edit modals show old Medicare value and field, respectively
6. Go to http://localhost:8000/register/list-registration-requests/, select a record, and confirm the view modal shows old Medicare value (try second record on listing)
7. On the same record, click through to 'Renew Record' and confirm that, in any entities on that record, the new Medicare fields appear (renew does not support old field)
8. Confirm that, when you update the `MEDICARE_UPDATE_DEPLOY_DATE` setting's value, that both the registration form and renew form only ever show the new Medicare fields, and that any test records with a 'Created' date before that setting show old medicare field, and any after show new Medicare fields

## UI

…


## Notes
I have put this new setting in secrets.py so to not have to make any updates to Core-CMS, but please let me know if this setting is better in a different settings file.
<!--
…
-->
