### PR TITLE
refactor: delete SASS dep, use native CSS

### DIFF
--- a/apcd_cms/src/client/package-lock.json
+++ b/apcd_cms/src/client/package-lock.json
@@ -52,7 +52,6 @@
         "react-test-renderer": "^17.0.2",
         "redux-mock-store": "^1.5.3",
         "redux-saga-test-plan": "^4.0.0-rc.3",
-        "sass": "^1.42.1",
         "stylelint": "^14.4.0",
         "stylelint-config-recommended": "^7.0.0",
         "stylelint-config-standard": "^25.0.0",
@@ -9771,12 +9770,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immutable": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
-      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
-      "dev": true
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -16437,23 +16430,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/sass": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
-      "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/saxes": {
       "version": "5.0.1",

--- a/apcd_cms/src/client/package.json
+++ b/apcd_cms/src/client/package.json
@@ -75,7 +75,6 @@
     "react-test-renderer": "^17.0.2",
     "redux-mock-store": "^1.5.3",
     "redux-saga-test-plan": "^4.0.0-rc.3",
-    "sass": "^1.42.1",
     "stylelint": "^14.4.0",
     "stylelint-config-recommended": "^7.0.0",
     "stylelint-config-standard": "^25.0.0",

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/EditRecordModal.tsx
@@ -12,7 +12,7 @@ import { Formik, Field, Form, ErrorMessage } from 'formik';
 import { fetchUtil } from 'utils/fetchUtil';
 import * as Yup from 'yup';
 import { UserRow } from 'hooks/admin';
-import styles from './ViewUsers.module.scss';
+import styles from './ViewUsers.module.css';
 import { formatDate } from 'utils/dateUtil';
 import QueryWrapper from 'core-wrappers/QueryWrapper';
 import FieldWrapper from 'core-wrappers/FieldWrapperFormik';

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewRecordModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Modal, ModalHeader, Row, Col, ModalBody } from 'reactstrap';
 import { UserRow } from 'hooks/admin';
-import styles from './ViewUsers.module.scss';
+import styles from './ViewUsers.module.css';
 import { formatDate } from 'utils/dateUtil';
 
 interface UserDetailsModalProps {

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.module.css
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.module.css
@@ -1,8 +1,8 @@
-$modal-width: 55%;
-
 .customModal {
-  max-width: $modal-width !important;
-  width: $modal-width;
+  --width: 55%;
+
+  max-width: var(--width) !important;
+  width: var(--width);
 }
 
 .modal-header {
@@ -12,18 +12,18 @@ $modal-width: 55%;
 }
 
 .customModalTitle {
-  text-transform: none !important; // Prevent text from being all caps
+  text-transform: none !important; /* Prevent text from being all caps */
   font-size: 2.5rem;
-  margin: 0; // Ensure there's no margin
+  margin: 0; /* Ensure there's no margin */
 }
 
 .customLabel {
-  font-size: 1.5rem; // Adjust the font size as needed
+  font-size: 1.5rem; /* Adjust the font size as needed */
 }
 
 .customSubmitButton {
-  font-size: 1.5rem; // Increase font size
-  padding: 0.75rem 1.5rem; // Increase padding
+  font-size: 1.5rem; /* Increase font size */
+  padding: 0.75rem 1.5rem; /* Increase padding */
 }
 
 .viewRecord {

--- a/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
+++ b/apcd_cms/src/client/src/components/Admin/ViewUsers/ViewUsers.tsx
@@ -4,7 +4,7 @@ import ViewRecordModal from './ViewRecordModal';
 import EditRecordModal from './EditRecordModal';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import Paginator from 'core-components/Paginator';
-import styles from './ViewUsers.module.scss';
+import styles from './ViewUsers.module.css';
 import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const ViewUsers: React.FC = () => {

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/EditRecordModal.tsx
@@ -14,7 +14,7 @@ import { Formik, Field, Form, ErrorMessage } from 'formik';
 import { fetchUtil } from 'utils/fetchUtil';
 import * as Yup from 'yup';
 import { SubmitterUserRow } from 'hooks/admin';
-import styles from './ViewSubmitterUsers.module.scss';
+import styles from './ViewSubmitterUsers.module.css';
 
 interface EditRecordModalProps {
   isOpen: boolean;

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewRecordModal.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewRecordModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Modal, ModalHeader, Row, Col, ModalBody } from 'reactstrap';
 import { SubmitterUserRow } from 'hooks/admin';
-import styles from './ViewSubmitterUsers.module.scss';
+import styles from './ViewSubmitterUsers.module.css';
 // import { formatDate } from 'utils/dateUtil';
 
 interface UserDetailsModalProps {

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.module.css
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.module.css
@@ -1,8 +1,8 @@
-$modal-width: 55%;
-
 .customModal {
-  max-width: $modal-width !important;
-  width: $modal-width;
+  --width: 55%;
+
+  max-width: var(--width) !important;
+  width: var(--width);
 }
 
 .modal-header {
@@ -12,18 +12,18 @@ $modal-width: 55%;
 }
 
 .customModalTitle {
-  text-transform: none !important; // Prevent text from being all caps
+  text-transform: none !important; /* Prevent text from being all caps */
   font-size: 2.5rem;
-  margin: 0; // Ensure there's no margin
+  margin: 0; /* Ensure there's no margin */
 }
 
 .customLabel {
-  font-size: 1.5rem; // Adjust the font size as needed
+  font-size: 1.5rem; /* Adjust the font size as needed */
 }
 
 .customSubmitButton {
-  font-size: 1.5rem; // Increase font size
-  padding: 0.75rem 1.5rem; // Increase padding
+  font-size: 1.5rem; /* Increase font size */
+  padding: 0.75rem 1.5rem; /* Increase padding */
 }
 
 .viewRecord {

--- a/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
+++ b/apcd_cms/src/client/src/components/Submitter/ViewSubmitterUsers/ViewSubmitterUsers.tsx
@@ -8,7 +8,7 @@ import ViewRecordModal from './ViewRecordModal';
 import EditRecordModal from './EditRecordModal';
 import LoadingSpinner from 'core-components/LoadingSpinner';
 import Paginator from 'core-components/Paginator';
-import styles from './ViewSubmitterUsers.module.scss';
+import styles from './ViewSubmitterUsers.module.css';
 import { ClearOptionsButton } from 'apcd-components/ClearOptionsButton';
 
 export const ViewSubmitterUsers: React.FC = () => {

--- a/apcd_cms/src/client/vite.config.ts
+++ b/apcd_cms/src/client/vite.config.ts
@@ -5,7 +5,6 @@ import path, {resolve} from 'path';
 
 
 export default defineConfig({
-    css: { preprocessorOptions: { scss: { charset: false } } },
     build: {
       outDir: 'dist',
       rollupOptions: {


### PR DESCRIPTION
## Overview

Delete SASS usage. Use native CSS.

## Related

- fixes https://github.com/TACC/APCD-CMS/security/dependabot/42
- probably fixes [other dependabot security issues](https://github.com/TACC/APCD-CMS/security/dependabot)

## Changes

- **deleted** SASS dependency & config
- **renamed** `.scss` to `.css`
- **changed** SASS syntax to native CSS syntax

## Testing

1. Run `npm list immutable sass`, see no results.
2. Verify pages related to these tasks still render as they had:
    - Edit Records/Users
    - View Records/Users

> [!tip]
> [Deployed](https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_Deploy/4118/console) to [dev server](https://dev.a2cps.tacc.utexas.edu/).

## UI

```
client % npm list immutable sass
apcd-components@0.1.0 /.../Code/TACC/APCD-CMS/apcd_cms/src/client
└─(empty)
```

| before | after |
| - | - |
| <img width="900" height="475" alt="old view" src="https://github.com/user-attachments/assets/e2a5eca6-1e17-4bd9-b8d8-6f8a97ef9035" /> | <img width="900" height="475" alt="new view" src="https://github.com/user-attachments/assets/3988c06a-200d-426f-bb95-65d78656e159" /> |

| before | after |
| - | - |
| <img width="900" height="475" alt="old edit" src="https://github.com/user-attachments/assets/451fc23a-10f2-492a-8b0a-ae4c2b3d62fa" /> | <img width="900" height="475" alt="new edit" src="https://github.com/user-attachments/assets/d4705886-04a5-4d79-a961-c4ce1b342cb4" /> |
