### PR TITLE
refactor: custom app settings

### DIFF
--- a/apcd_cms/Dockerfile
+++ b/apcd_cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.39.2
+FROM taccwma/core-cms:v4.40.0-rc10
 
 WORKDIR /code
 

--- a/apcd_cms/Dockerfile
+++ b/apcd_cms/Dockerfile
@@ -1,4 +1,4 @@
-FROM taccwma/core-cms:v4.39.2
+FROM taccwma/core-cms:v4.40.0-rc6
 
 WORKDIR /code
 

--- a/apcd_cms/src/taccsite_cms/custom_app_settings.py
+++ b/apcd_cms/src/taccsite_cms/custom_app_settings.py
@@ -1,4 +1,0 @@
-CUSTOM_APPS = ['apps.admin_regis_table', 'apps.apcd_login', 'apps.registrations', 'apps.submissions', 'apps.exception', 'apps.admin_submissions', 'apps.admin_extension', 'apps.admin_exception', 'apps.extension', 'apps.submitter_renewals_listing', 'apps.view_users', 'apps.components.paginator', 'apps.utils', 'apps.common_api', 'apps.view_submitter_users']
-CUSTOM_MIDDLEWARE = []
-STATICFILES_DIRS = ('taccsite_custom/apcd_cms', 'apps/admin_regis_table', 'apps/registrations', 'apps/submissions', 'apps/exception', 'apps/extension', 'apps/submitter_renewals_listing', 'apps/view_users', 'apps/components/paginator', 'apps/utils', 'client/dist', 'apps/common_api')
-

--- a/apcd_cms/src/taccsite_cms/settings_apps.py
+++ b/apcd_cms/src/taccsite_cms/settings_apps.py
@@ -1,0 +1,34 @@
+EXTRA_INSTALLED_APPS = [
+    'apps.admin_regis_table',
+    'apps.apcd_login',
+    'apps.registrations',
+    'apps.submissions',
+    'apps.exception',
+    'apps.admin_submissions',
+    'apps.admin_extension',
+    'apps.admin_exception',
+    'apps.extension',
+    'apps.submitter_renewals_listing',
+    'apps.view_users',
+    'apps.components.paginator',
+    'apps.utils',
+    'apps.common_api',
+    'apps.view_submitter_users'
+]
+
+EXTRA_MIDDLEWARE = []
+
+EXTRA_STATICFILES_DIRS = (
+    'taccsite_custom/apcd_cms',
+    'apps/admin_regis_table',
+    'apps/registrations',
+    'apps/submissions',
+    'apps/exception',
+    'apps/extension',
+    'apps/submitter_renewals_listing',
+    'apps/view_users',
+    'apps/components/paginator',
+    'apps/utils',
+    'client/dist',
+    'apps/common_api'
+)


### PR DESCRIPTION
## Overview

[Core-CMS v4.40.0-rc10] refactors custom app settings. ~~The change is _**not** backwards compatible_, so **all** clients (with such settings) **must** update to use the CMS since that version.~~

[Core-CMS v4.40.0-rc10]: https://github.com/TACC/Core-CMS/releases/tag/v4.40.0-rc10

> [!IMPORTANT]
> To run locally, developers must [update their `settings_custom.py`](https://github.com/TACC/Core-Portal-Deployments/pull/197/changes/2dc4d49d).

## Related

- requires [Core-CMS v4.40.0-rc10]
- requires https://github.com/TACC/Core-Portal-Deployments/pull/197
- follow-up to https://github.com/TACC/APCD-CMS/pull/43

## Changes

I followed [`Core-CMS:/docs/upgrade-project.md`: "from v4.39 to v4.40"](https://github.com/TACC/Core-CMS/blob/383d5c7/docs/upgrade-project.md#from-v439-to-v440).

<details>

- **updated** Core-CMS
- **renamed** `custom_app_settings.py` → `settings_apps.py`
- **renamed** custom app settings
- **updated** `settings_custom.py`
    - local .gitignored
    - [remote configuration](https://github.com/TACC/Core-Portal-Deployments/commit/04afdd2)

</details>

## Testing

1. Build and deploy.
2. Verify all apps load.